### PR TITLE
Fix prediction condition based on class indices

### DIFF
--- a/server/predict.py
+++ b/server/predict.py
@@ -49,7 +49,7 @@ def predict_eye(img_path):
         pred = model.predict(img_array)
         log(f"Raw prediction for {img_path}: {pred}")
         # Binary classification threshold
-        return "Cataract" if pred[0][0] >= 0.5 else "Normal"
+        return "Normal" if pred[0][0] >= 0.5 else "Cataract"
     except Exception as e:
         log(f"ERROR predicting image {img_path}: {str(e)}")
         return f"Error: {str(e)}"


### PR DESCRIPTION
The condition for prediction was reversed. Based on the class indices {'cataract': 0, 'normal': 1}, the correct condition should be:
return "Normal" if pred[0][0] >= 0.5 else "Cataract"
